### PR TITLE
Upgrade `eventsource` to `v4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This engine adds support for load testing [Server-Sent Events](https://developer
 
 - Open, hold and close connections to SSE-based URLs
 - Set up custom event and message handlers
+- HTTP/2 support via custom fetch dispatcher
+- Custom headers support
+
+Requires Node.js >= 20.
 
 See [`test.yml`](./test.yml) for an example test script.
 
@@ -21,6 +25,26 @@ See [`test.yml`](./test.yml) for an example test script.
     ```
 
 Artillery will be able to load the engine and test SSE endpoints now.
+
+## Engine configuration
+
+Configure the engine in your Artillery script under `config.engines.sse`:
+
+```yaml
+config:
+  engines:
+    sse:
+      # Custom headers (optional)
+      headers:
+        Authorization: "Bearer my-token"
+      # Enable HTTP/2 negotiation (optional, requires undici)
+      http2: true
+      # Custom TLS settings (optional)
+      https:
+        rejectUnauthorized: false
+```
+
+HTTP/2 support requires the `undici` package: `npm install undici`.
 
 Run the bundled example ([`test.yml`](./test.yml))
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const EventSource = require('eventsource');
+const { EventSource } = require('eventsource');
 const A = require('async');
 
 class SSEEngine {
@@ -13,6 +13,40 @@ class SSEEngine {
     return this;
   }
 
+  _buildFetchOption() {
+    const config = this.eventSourceConfig;
+    const customHeaders = config.headers || {};
+    const useHttp2 = config.http2 === true;
+    const rejectUnauthorized = config.https?.rejectUnauthorized;
+
+    const hasCustomHeaders = Object.keys(customHeaders).length > 0;
+    const needsCustomFetch = hasCustomHeaders || useHttp2 || rejectUnauthorized !== undefined;
+
+    if (!needsCustomFetch) {
+      return {};
+    }
+
+    let dispatcher;
+    if (useHttp2 || rejectUnauthorized !== undefined) {
+      const { Agent } = require('undici');
+      dispatcher = new Agent({
+        allowH2: useHttp2,
+        ...(rejectUnauthorized !== undefined ? { connect: { rejectUnauthorized } } : {}),
+      });
+    }
+
+    return {
+      fetch: (input, init) => {
+        const fetchFn = dispatcher ? require('undici').fetch : globalThis.fetch;
+        return fetchFn(input, {
+          ...init,
+          ...(hasCustomHeaders ? { headers: { ...init.headers, ...customHeaders } } : {}),
+          ...(dispatcher ? { dispatcher } : {}),
+        });
+      },
+    };
+  }
+
   createScenario(spec, events) {
     const self = this;
 
@@ -23,23 +57,24 @@ class SSEEngine {
 
           steps.push(function open(next) {
             // TODO: need to wait for state here / handle connection error, e.g. with invalid URL
-            const es = new EventSource(self.target, self.eventSourceConfig);
-            es.on('error', (err) => {
-              if (err.status) {
-                events.emit('counter', `sse.error.${err.status}`, 1)
+            const fetchOption = self._buildFetchOption();
+            const es = new EventSource(self.target, fetchOption);
+            es.addEventListener('error', (err) => {
+              if (err.code) {
+                events.emit('counter', `sse.error.${err.code}`, 1)
               } else {
                 events.emit('counter', 'sse.error', 1);
               }
             });
 
-            es.on('message', (_msg) => {
+            es.addEventListener('message', (_msg) => {
               events.emit('counter', 'sse.message', 1);
             });
 
             if (spec.onMessage) {
               // TODO: Warn if no processor function
               if (self.script.config.processor?.[spec.onMessage]) {
-                es.on('message', (msg) => {
+                es.addEventListener('message', (msg) => {
                   self.script.config.processor[spec.onMessage].call(null, msg, initialContext, events);
                 });
               }
@@ -49,14 +84,14 @@ class SSEEngine {
               for(const handlerSpec of spec.onEvent) {
                 // TODO: Warn if no processor function
                 if (self.script.config.processor?.[handlerSpec.handler]) {
-                  es.on(handlerSpec.eventName, (e) => {
+                  es.addEventListener(handlerSpec.eventName, (e) => {
                     self.script.config.processor[handlerSpec.handler].call(null, e, initialContext, events);
                   });
                 }
               }
             }
 
-            es.on('open', () => {
+            es.addEventListener('open', () => {
               events.emit('counter', 'sse.open', 1);
             });
             initialContext.es = es;

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class SSEEngine {
   }
 
   _buildFetchOption() {
-    const config = this.eventSourceConfig;
+    const config = this._migrateV2Config(this.eventSourceConfig);
     const customHeaders = config.headers || {};
     const useHttp2 = config.http2 === true;
     const rejectUnauthorized = config.https?.rejectUnauthorized;
@@ -45,6 +45,34 @@ class SSEEngine {
         });
       },
     };
+  }
+
+  _migrateV2Config(config) {
+    const migrated = { ...config };
+    const warn = (old, replacement) => {
+      console.warn(`artillery-engine-sse: '${old}' is deprecated. Use '${replacement}' instead.`);
+    };
+
+    // v2 withCredentials → fetch credentials option
+    if (migrated.withCredentials !== undefined) {
+      warn('withCredentials', 'headers');
+      delete migrated.withCredentials;
+    }
+
+    // v2 top-level rejectUnauthorized → https.rejectUnauthorized
+    if (migrated.rejectUnauthorized !== undefined) {
+      warn('rejectUnauthorized', 'https.rejectUnauthorized');
+      migrated.https = { ...migrated.https, rejectUnauthorized: migrated.rejectUnauthorized };
+      delete migrated.rejectUnauthorized;
+    }
+
+    // v2 proxy → not yet supported in v4 engine
+    if (migrated.proxy !== undefined) {
+      warn('proxy', 'a custom fetch function');
+      delete migrated.proxy;
+    }
+
+    return migrated;
   }
 
   createScenario(spec, events) {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [],
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
     "async": "^3.2.4",
-    "eventsource": "^2.0.2"
+    "eventsource": "^4.0.0"
   },
   "devDependencies": {
     "express": "^4.18.2",

--- a/test.yml
+++ b/test.yml
@@ -7,7 +7,9 @@ config:
       arrivalRate: 1
   engines:
     sse: {}
-      # withCredentials: false
+      # headers:
+      #   Authorization: "Bearer my-token"
+      # http2: true
 scenarios:
   - engine: sse
     onMessage: handleSSEMessage


### PR DESCRIPTION
Upgrades `eventsource` to `v4.0` to benefit from a more modern fetch-based HTTP client, which enables HTTP/2 connection negotiation when configured with a `undici` as a dispatcher (`allowH2: true`).

Accommodates major version API updates and builds a `fetch` config with a best effort toward backward compatibility from the passthru strategy in `v2`.